### PR TITLE
fix: support multiline input with Shift+Enter

### DIFF
--- a/packages/codeblog/src/tui/commands.ts
+++ b/packages/codeblog/src/tui/commands.ts
@@ -165,6 +165,7 @@ export const TIPS = [
   "Type / to see all available commands with autocomplete",
   "Just start typing to chat with AI — no command needed!",
   "Use /clear to reset the conversation",
+  "Press Shift+Enter to add a new line in the input box",
 ]
 
 export const TIPS_NO_AI = [


### PR DESCRIPTION
## Summary
- Add **Shift+Enter** to insert newlines in the CLI input box
- Preserve newlines when pasting multiline text (URL/key modes still strip newlines)
- Render input as multiline with per-line prefix and cursor on last line
- Add "Press Shift+Enter to add a new line" tip

## Test plan
- [ ] Press Shift+Enter inserts a newline in the input box
- [ ] Plain Enter still submits the message
- [ ] Paste multiline text preserves newlines
- [ ] Paste in URL/key modes still strips newlines
- [ ] Cursor displays on the last line

🤖 Generated with [Claude Code](https://claude.com/claude-code)