### PR TITLE
fix: clear stale MCP connection and tool cache on logout

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "codeblog-app",
       "dependencies": {
-        "codeblog-mcp": "^2.5.1",
+        "codeblog-mcp": "^2.7.0",
       },
       "devDependencies": {
         "@tsconfig/bun": "1.0.9",
@@ -440,7 +440,7 @@
 
     "codeblog-app": ["codeblog-app@workspace:packages/codeblog"],
 
-    "codeblog-mcp": ["codeblog-mcp@2.5.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.26.0", "zod": "^3.24.0" }, "optionalDependencies": { "better-sqlite3": "^12.6.2" }, "bin": { "codeblog-mcp": "dist/cli.js" } }, "sha512-83UtkNlED/+ngWzHXanz2IyuO4wfnKhQ1G7wMvLXrwkSpmkczzZt7YpcJzelcrEcOJSXAW8fN4a6sLVW/Qi+Eg=="],
+    "codeblog-mcp": ["codeblog-mcp@2.7.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.26.0", "zod": "^3.24.0" }, "optionalDependencies": { "better-sqlite3": "^12.6.2" }, "bin": { "codeblog-mcp": "dist/cli.js" } }, "sha512-49UdjUd2TvMi2uXNXm2lC77/gamfWLphRvfy3I2cd0Vq1IFZJn0/bw7prB85RhsE2+yMQ3xe2IGS06osROBfrQ=="],
 
     "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
@@ -970,8 +970,6 @@
 
     "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
 
-    "codeblog-app/codeblog-mcp": ["codeblog-mcp@2.7.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.26.0", "zod": "^3.24.0" }, "optionalDependencies": { "better-sqlite3": "^12.6.2" }, "bin": { "codeblog-mcp": "dist/cli.js" } }, "sha512-49UdjUd2TvMi2uXNXm2lC77/gamfWLphRvfy3I2cd0Vq1IFZJn0/bw7prB85RhsE2+yMQ3xe2IGS06osROBfrQ=="],
-
     "codeblog-mcp/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
@@ -993,8 +991,6 @@
     "tedious/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "tsx/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
-
-    "codeblog-app/codeblog-mcp/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "tar-stream/bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     ]
   },
   "dependencies": {
-    "codeblog-mcp": "^2.5.1"
+    "codeblog-mcp": "^2.7.0"
   }
 }

--- a/packages/codeblog/src/cli/cmd/logout.ts
+++ b/packages/codeblog/src/cli/cmd/logout.ts
@@ -7,8 +7,12 @@ export const LogoutCommand: CommandModule = {
   command: "logout",
   describe: "Logout from CodeBlog",
   handler: async () => {
+    const { McpBridge } = await import("../../mcp/client")
+    const { clearChatToolsCache } = await import("../../ai/tools")
     await Auth.remove()
     await Config.clearActiveAgent()
+    await McpBridge.disconnect()
+    clearChatToolsCache()
     UI.success("Logged out successfully")
   },
 }

--- a/packages/codeblog/src/tui/commands.ts
+++ b/packages/codeblog/src/tui/commands.ts
@@ -72,7 +72,13 @@ export function createCommands(deps: CommandDeps): CmdDef[] {
     { name: "/logout", description: "Sign out of CodeBlog", action: async () => {
       try {
         const { Auth } = await import("../auth")
+        const { Config } = await import("../config")
+        const { McpBridge } = await import("../mcp/client")
+        const { clearChatToolsCache } = await import("../ai/tools")
         await Auth.remove()
+        await Config.clearActiveAgent()
+        await McpBridge.disconnect()
+        clearChatToolsCache()
         deps.showMsg("Logged out.", deps.colors.text)
         deps.onLogout()
       } catch (err) { deps.showMsg(`Logout failed: ${err instanceof Error ? err.message : String(err)}`, deps.colors.error) }


### PR DESCRIPTION
## Summary
- **Disconnect MCP bridge** and **clear chat tools cache** during logout in both CLI (`logout.ts`) and TUI (`/logout` command), preventing stale auth state from persisting across re-logins
- **Clear active agent config** in TUI logout to match CLI behavior
- Bump `codeblog-mcp` dependency from `^2.5.1` to `^2.7.0`

## Test plan
- [ ] Run `codeblog logout` via CLI, then `codeblog login` — verify MCP tools work with fresh credentials
- [ ] In TUI, run `/logout` then `/login` — verify no stale auth errors
- [ ] Verify `bun install` succeeds with updated `codeblog-mcp` version

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)